### PR TITLE
Add Wood House Designer WordPress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# WoodHouseDesigner
-Wood House Designer
+# Wood House Designer
+
+WordPress plugin that powers an interactive Konva.js canvas to design custom wooden houses. It includes a configurable grid, base geometric primitives, export tooling and a ready-to-use page template.
+
+## Plugin Setup
+
+1. Copy the `wp-content/plugins/wood-house-designer` directory into your WordPress installation.
+2. Activate **Wood House Designer** from the WordPress Plugins page.
+3. Configure the default grid size, scale ratio and canvas size from **Settings → Wood House Designer**.
+4. Create a page and either:
+   - Insert the `[wood_house_designer]` shortcode in the content, or
+   - Assign the **Wood House Designer App** page template to render the full application layout.
+
+## Features
+
+- Konva.js powered design surface with snap grid and real scale guides.
+- Toolbox with draggable wall, window, beam and dimension label primitives.
+- Export button that generates a JSON package with project metadata and scene data.
+- Accessible layout with dedicated header, tools panel, canvas and status bar regions.
+
+## Development
+
+Assets live under `assets/css` and `assets/js`. The plugin bootstrap file is `wood-house-designer.php` inside the plugin directory.

--- a/wp-content/plugins/wood-house-designer/assets/css/app.css
+++ b/wp-content/plugins/wood-house-designer/assets/css/app.css
@@ -1,0 +1,153 @@
+
+:root {
+    --whd-primary: #2f855a;
+    --whd-secondary: #f7fafc;
+    --whd-border: #cbd5e0;
+    --whd-text: #2d3748;
+    --whd-header-height: 50px;
+}
+
+.whd-app {
+    display: flex;
+    flex-direction: column;
+    min-height: 600px;
+    border: 1px solid var(--whd-border);
+    background: #ffffff;
+    font-family: 'Segoe UI', Tahoma, sans-serif;
+    color: var(--whd-text);
+}
+
+.whd-header {
+    height: var(--whd-header-height);
+    background: var(--whd-primary);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    padding: 0 1.5rem;
+    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+}
+
+.whd-header__title {
+    font-size: 1.25rem;
+    margin: 0;
+    letter-spacing: 0.05em;
+}
+
+.whd-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    background: var(--whd-secondary);
+}
+
+.whd-tools {
+    flex-basis: 20%;
+    max-width: 280px;
+    min-width: 220px;
+    background: #fff;
+    border-right: 1px solid var(--whd-border);
+    padding: 1rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.whd-tools__title {
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+    color: var(--whd-primary);
+    letter-spacing: 0.04em;
+}
+
+.whd-tools__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.whd-tool-button {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--whd-border);
+    background: #fdfdfd;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.2s, box-shadow 0.2s;
+}
+
+.whd-tool-button:hover,
+.whd-tool-button:focus {
+    background: #edf2f7;
+    box-shadow: 0 0 0 3px rgba(47, 133, 90, 0.25);
+    outline: none;
+}
+
+.whd-canvas {
+    flex-basis: 80%;
+    flex-grow: 1;
+    padding: 1rem;
+    min-width: 0;
+}
+
+.whd-canvas__stage {
+    width: 100%;
+    height: 100%;
+    background: #fff;
+    border: 1px solid var(--whd-border);
+    border-radius: 8px;
+    position: relative;
+    overflow: hidden;
+}
+
+.whd-status {
+    min-height: 38px;
+    display: flex;
+    align-items: center;
+    padding: 0 1rem;
+    background: #1a202c;
+    color: #e2e8f0;
+    font-size: 0.9rem;
+    border-top: 1px solid #2d3748;
+}
+
+.whd-status span {
+    flex: 1;
+}
+
+.whd-export-output {
+    width: 100%;
+    margin-top: 1rem;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.8rem;
+}
+
+@media (max-width: 1024px) {
+    .whd-body {
+        flex-direction: column;
+    }
+
+    .whd-tools {
+        flex-basis: auto;
+        max-width: 100%;
+        border-right: none;
+        border-bottom: 1px solid var(--whd-border);
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .whd-canvas {
+        flex-basis: auto;
+        min-height: 400px;
+    }
+}
+
+@media (max-width: 600px) {
+    .whd-tools {
+        flex-direction: column;
+    }
+}

--- a/wp-content/plugins/wood-house-designer/assets/js/app.js
+++ b/wp-content/plugins/wood-house-designer/assets/js/app.js
@@ -1,0 +1,326 @@
+(function () {
+    'use strict';
+
+    const config = window.WoodHouseDesignerConfig || {};
+
+    function initApp() {
+        const container = document.getElementById('whd-stage-container');
+        if (!container || typeof Konva === 'undefined') {
+            return;
+        }
+
+        const shapesList = document.getElementById('whd-shape-list');
+        const exportBtn = document.getElementById('whd-export-project');
+
+        if (!shapesList) {
+            return;
+        }
+
+        const width = config.canvasWidth || container.clientWidth || 1000;
+        const height = config.canvasHeight || container.clientHeight || 600;
+        const gridSize = config.gridSize || 50;
+        const scaleRatio = config.scaleRatio || 1;
+
+        container.style.minHeight = height + 'px';
+
+        const stage = new Konva.Stage({
+            container: 'whd-stage-container',
+            width,
+            height
+        });
+
+        const gridLayer = new Konva.Layer({ listening: false });
+        const drawingLayer = new Konva.Layer();
+
+        stage.add(gridLayer);
+        stage.add(drawingLayer);
+
+        let stageWidth = width;
+        let stageHeight = height;
+
+        function resizeStage() {
+            const containerWidth = container.clientWidth || stageWidth;
+            const containerHeight = container.clientHeight || stageHeight;
+            stageWidth = containerWidth || width;
+            stageHeight = containerHeight || height;
+            stage.size({ width: stageWidth, height: stageHeight });
+            drawGrid(gridLayer, stageWidth, stageHeight, gridSize, scaleRatio);
+        }
+
+        window.addEventListener('resize', function () {
+            clearTimeout(window.__whdResizeTimer);
+            window.__whdResizeTimer = setTimeout(resizeStage, 150);
+        });
+
+        resizeStage();
+        updateStatus('Ready. Use the toolbox to add elements.');
+
+        const transformer = new Konva.Transformer({
+            rotateEnabled: true,
+            enabledAnchors: [
+                'top-left', 'top-center', 'top-right',
+                'middle-left', 'middle-right',
+                'bottom-left', 'bottom-center', 'bottom-right'
+            ]
+        });
+        drawingLayer.add(transformer);
+
+        stage.on('click tap', function (evt) {
+            if (evt.target === stage) {
+                transformer.nodes([]);
+                updateStatus('');
+                return;
+            }
+
+            if (!evt.target.draggable()) {
+                return;
+            }
+
+            transformer.nodes([evt.target]);
+            const dims = getDimensions(evt.target, scaleRatio);
+            updateStatus(`${dims}`);
+        });
+
+        stage.on('mousemove', function () {
+            const pointer = stage.getPointerPosition();
+            if (!pointer) {
+                return;
+            }
+            const activeNodes = transformer.nodes();
+            if (activeNodes.length > 0) {
+                return;
+            }
+            const scaledX = (pointer.x / gridSize * scaleRatio).toFixed(2);
+            const scaledY = (pointer.y / gridSize * scaleRatio).toFixed(2);
+            updateStatus(`Cursor: ${scaledX} × ${scaledY} m`);
+        });
+
+        const tools = getToolsConfig(scaleRatio);
+        tools.forEach(function (tool) {
+            const button = document.createElement('button');
+            button.className = 'whd-tool-button';
+            button.type = 'button';
+            button.textContent = tool.label;
+            button.addEventListener('click', function () {
+                const node = tool.factory({ gridSize, scaleRatio });
+                node.on('dragmove transform', function () {
+                    updateDimensionLabel(node, scaleRatio);
+                    if (transformer.nodes().includes(node)) {
+                        const dims = getDimensions(node, scaleRatio);
+                        updateStatus(`${dims}`);
+                    }
+                });
+                drawingLayer.add(node);
+                drawingLayer.draw();
+                transformer.nodes([node]);
+                const dims = getDimensions(node, scaleRatio);
+                updateStatus(`${dims}`);
+            });
+            shapesList.appendChild(button);
+        });
+
+        if (exportBtn) {
+            exportBtn.addEventListener('click', function () {
+                const json = stage.toJSON();
+                const metadata = {
+                    version: config.appVersion || '1.0.0',
+                    generatedAt: new Date().toISOString(),
+                    scaleRatio,
+                    gridSize,
+                    canvas: { width, height }
+                };
+                const payload = JSON.stringify({ metadata, stage: JSON.parse(json) }, null, 2);
+                downloadFile((config.exportFileName || 'wood-house-project') + '.json', payload);
+                updateStatus('Project exported successfully.');
+            });
+        }
+    }
+
+    function drawGrid(layer, width, height, gridSize, scaleRatio) {
+        layer.destroyChildren();
+        const elements = [];
+        const majorEvery = 5;
+        const majorColor = '#a0aec0';
+        const minorColor = '#e2e8f0';
+
+        for (let i = 0; i <= width / gridSize; i++) {
+            const isMajor = i % majorEvery === 0;
+            elements.push(new Konva.Line({
+                points: [i * gridSize, 0, i * gridSize, height],
+                stroke: isMajor ? majorColor : minorColor,
+                strokeWidth: isMajor ? 1 : 0.5
+            }));
+            if (isMajor && i > 0) {
+                elements.push(new Konva.Text({
+                    x: i * gridSize + 4,
+                    y: 4,
+                    text: `${(i * scaleRatio).toFixed(2)} m`,
+                    fontSize: 10,
+                    fill: '#4a5568'
+                }));
+            }
+        }
+
+        for (let j = 0; j <= height / gridSize; j++) {
+            const isMajor = j % majorEvery === 0;
+            elements.push(new Konva.Line({
+                points: [0, j * gridSize, width, j * gridSize],
+                stroke: isMajor ? majorColor : minorColor,
+                strokeWidth: isMajor ? 1 : 0.5
+            }));
+            if (isMajor && j > 0) {
+                elements.push(new Konva.Text({
+                    x: 4,
+                    y: j * gridSize + 4,
+                    text: `${(j * scaleRatio).toFixed(2)} m`,
+                    fontSize: 10,
+                    fill: '#4a5568'
+                }));
+            }
+        }
+
+        elements.forEach(function (item) {
+            layer.add(item);
+        });
+
+        layer.draw();
+    }
+
+    function getToolsConfig(scaleRatio) {
+        return [
+            {
+                label: 'Wall (Rectangle)',
+                factory: function ({ gridSize }) {
+                    return new Konva.Rect({
+                        x: gridSize * 2,
+                        y: gridSize * 2,
+                        width: gridSize * 3,
+                        height: gridSize,
+                        fill: 'rgba(66, 153, 225, 0.25)',
+                        stroke: '#2b6cb0',
+                        strokeWidth: 2,
+                        draggable: true,
+                        name: 'wall'
+                    });
+                }
+            },
+            {
+                label: 'Window (Circle)',
+                factory: function ({ gridSize }) {
+                    return new Konva.Circle({
+                        x: gridSize * 3,
+                        y: gridSize * 3,
+                        radius: gridSize / 2,
+                        fill: 'rgba(236, 201, 75, 0.35)',
+                        stroke: '#d69e2e',
+                        strokeWidth: 2,
+                        draggable: true,
+                        name: 'window'
+                    });
+                }
+            },
+            {
+                label: 'Beam (Line)',
+                factory: function ({ gridSize }) {
+                    return new Konva.Line({
+                        points: [gridSize, gridSize, gridSize * 4, gridSize * 2],
+                        stroke: '#805ad5',
+                        strokeWidth: 4,
+                        lineCap: 'round',
+                        lineJoin: 'round',
+                        draggable: true,
+                        name: 'beam'
+                    });
+                }
+            },
+            {
+                label: 'Dimension Label',
+                factory: function ({ gridSize, scaleRatio }) {
+                    const group = new Konva.Group({
+                        x: gridSize * 2,
+                        y: gridSize * 4,
+                        draggable: true,
+                        name: 'dimension'
+                    });
+
+                    const line = new Konva.Line({
+                        points: [0, 0, gridSize * 2, 0],
+                        stroke: '#1a202c',
+                        strokeWidth: 2
+                    });
+
+                    const text = new Konva.Text({
+                        x: gridSize,
+                        y: -14,
+                        text: '',
+                        fontSize: 14,
+                        fill: '#1a202c',
+                        align: 'center'
+                    });
+                    text.offsetX(text.width() / 2);
+
+                    group.add(line);
+                    group.add(text);
+
+                    group.on('dragmove transform', function () {
+                        updateDimensionLabel(group, scaleRatio);
+                    });
+
+                    updateDimensionLabel(group, scaleRatio);
+
+                    return group;
+                }
+            }
+        ];
+    }
+
+    function getDimensions(node, scaleRatio) {
+        const box = node.getClientRect({ skipShadow: true, skipStroke: false });
+        const widthMeters = (box.width / getGridSize() * scaleRatio).toFixed(2);
+        const heightMeters = (box.height / getGridSize() * scaleRatio).toFixed(2);
+        return `Selected ${node.name() || node.className} - ${widthMeters}m x ${heightMeters}m`;
+
+        function getGridSize() {
+            return config.gridSize || 50;
+        }
+    }
+
+    function updateStatus(message) {
+        const statusEl = document.getElementById('whd-status-message');
+        if (statusEl) {
+            statusEl.textContent = message;
+        }
+    }
+
+    function updateDimensionLabel(node, scaleRatio) {
+        if (!node || typeof node.name !== 'function' || node.name() !== 'dimension') {
+            return;
+        }
+        const box = node.getClientRect({ skipShadow: true, skipStroke: false });
+        const widthMeters = (box.width / (config.gridSize || 50) * scaleRatio).toFixed(2);
+        const textNode = node.findOne('Text');
+        if (textNode) {
+            textNode.text(`${widthMeters} m`);
+            textNode.offsetX(textNode.width() / 2);
+        }
+    }
+
+    function downloadFile(filename, data) {
+        const blob = new Blob([data], { type: 'application/json' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(function () {
+            URL.revokeObjectURL(link.href);
+        }, 2000);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initApp);
+    } else {
+        initApp();
+    }
+})();

--- a/wp-content/plugins/wood-house-designer/includes/class-wood-house-designer-settings.php
+++ b/wp-content/plugins/wood-house-designer/includes/class-wood-house-designer-settings.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Settings management for Wood House Designer.
+ *
+ * @package WoodHouseDesigner
+ */
+
+if ( ! class_exists( 'Wood_House_Designer_Settings' ) ) {
+    /**
+     * Settings handler.
+     */
+    class Wood_House_Designer_Settings {
+        /**
+         * Singleton instance.
+         *
+         * @var Wood_House_Designer_Settings
+         */
+        protected static $instance = null;
+
+        /**
+         * Registered option name.
+         */
+        const OPTION_KEY = 'wood_house_designer_settings';
+
+        /**
+         * Default settings values.
+         *
+         * @var array<string, mixed>
+         */
+        protected $defaults = array(
+            'grid_size'        => 50,
+            'scale_ratio'      => 1.0,
+            'canvas_width'     => 1000,
+            'canvas_height'    => 600,
+            'export_file_name' => 'wood-house-project',
+        );
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @return Wood_House_Designer_Settings
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        private function __construct() {
+            add_action( 'admin_menu', array( $this, 'register_menu' ) );
+            add_action( 'admin_init', array( $this, 'register_settings' ) );
+        }
+
+        /**
+         * Register settings menu.
+         */
+        public function register_menu() {
+            add_options_page(
+                __( 'Wood House Designer', 'wood-house-designer' ),
+                __( 'Wood House Designer', 'wood-house-designer' ),
+                'manage_options',
+                'wood-house-designer',
+                array( $this, 'render_settings_page' )
+            );
+        }
+
+        /**
+         * Register plugin settings fields.
+         */
+        public function register_settings() {
+            register_setting( 'wood_house_designer_settings', self::OPTION_KEY, array( $this, 'sanitize_options' ) );
+
+            add_settings_section(
+                'wood_house_designer_general',
+                __( 'General Configuration', 'wood-house-designer' ),
+                '__return_false',
+                'wood_house_designer_settings'
+            );
+
+            add_settings_field(
+                'grid_size',
+                __( 'Grid Size (px)', 'wood-house-designer' ),
+                array( $this, 'render_number_field' ),
+                'wood_house_designer_settings',
+                'wood_house_designer_general',
+                array(
+                    'label_for' => 'grid_size',
+                    'min'       => 10,
+                    'step'      => 5,
+                )
+            );
+
+            add_settings_field(
+                'scale_ratio',
+                __( 'Scale Ratio (grid unit in meters)', 'wood-house-designer' ),
+                array( $this, 'render_number_field' ),
+                'wood_house_designer_settings',
+                'wood_house_designer_general',
+                array(
+                    'label_for' => 'scale_ratio',
+                    'min'       => 0.1,
+                    'step'      => 0.1,
+                )
+            );
+
+            add_settings_field(
+                'canvas_width',
+                __( 'Canvas Width (px)', 'wood-house-designer' ),
+                array( $this, 'render_number_field' ),
+                'wood_house_designer_settings',
+                'wood_house_designer_general',
+                array(
+                    'label_for' => 'canvas_width',
+                    'min'       => 400,
+                    'step'      => 10,
+                )
+            );
+
+            add_settings_field(
+                'canvas_height',
+                __( 'Canvas Height (px)', 'wood-house-designer' ),
+                array( $this, 'render_number_field' ),
+                'wood_house_designer_settings',
+                'wood_house_designer_general',
+                array(
+                    'label_for' => 'canvas_height',
+                    'min'       => 300,
+                    'step'      => 10,
+                )
+            );
+
+            add_settings_field(
+                'export_file_name',
+                __( 'Default Export Filename', 'wood-house-designer' ),
+                array( $this, 'render_text_field' ),
+                'wood_house_designer_settings',
+                'wood_house_designer_general',
+                array(
+                    'label_for' => 'export_file_name',
+                )
+            );
+        }
+
+        /**
+         * Render number input field.
+         *
+         * @param array $args Field arguments.
+         */
+        public function render_number_field( $args ) {
+            $options = $this->get_options();
+            $id      = esc_attr( $args['label_for'] );
+            $min     = isset( $args['min'] ) ? (float) $args['min'] : '';
+            $step    = isset( $args['step'] ) ? (float) $args['step'] : 'any';
+            $value   = isset( $options[ $id ] ) ? $options[ $id ] : '';
+            ?>
+            <input type="number" id="<?php echo $id; ?>" name="<?php echo esc_attr( self::OPTION_KEY . '[' . $id . ']' ); ?>" value="<?php echo esc_attr( $value ); ?>" min="<?php echo esc_attr( $min ); ?>" step="<?php echo esc_attr( $step ); ?>" class="small-text" />
+            <?php
+        }
+
+        /**
+         * Render text input field.
+         *
+         * @param array $args Field arguments.
+         */
+        public function render_text_field( $args ) {
+            $options = $this->get_options();
+            $id      = esc_attr( $args['label_for'] );
+            $value   = isset( $options[ $id ] ) ? $options[ $id ] : '';
+            ?>
+            <input type="text" id="<?php echo $id; ?>" name="<?php echo esc_attr( self::OPTION_KEY . '[' . $id . ']' ); ?>" value="<?php echo esc_attr( $value ); ?>" class="regular-text" />
+            <?php
+        }
+
+        /**
+         * Sanitize option values.
+         *
+         * @param array $input Raw form values.
+         *
+         * @return array Sanitized options.
+         */
+        public function sanitize_options( $input ) {
+            $input = is_array( $input ) ? $input : array();
+            $sanitized = $this->get_defaults();
+
+            if ( isset( $input['grid_size'] ) ) {
+                $sanitized['grid_size'] = max( 10, (int) $input['grid_size'] );
+            }
+
+            if ( isset( $input['scale_ratio'] ) ) {
+                $sanitized['scale_ratio'] = max( 0.1, (float) $input['scale_ratio'] );
+            }
+
+            if ( isset( $input['canvas_width'] ) ) {
+                $sanitized['canvas_width'] = max( 400, (int) $input['canvas_width'] );
+            }
+
+            if ( isset( $input['canvas_height'] ) ) {
+                $sanitized['canvas_height'] = max( 300, (int) $input['canvas_height'] );
+            }
+
+            if ( isset( $input['export_file_name'] ) ) {
+                $sanitized['export_file_name'] = sanitize_file_name( $input['export_file_name'] );
+                if ( empty( $sanitized['export_file_name'] ) ) {
+                    $sanitized['export_file_name'] = $this->defaults['export_file_name'];
+                }
+            }
+
+            return $sanitized;
+        }
+
+        /**
+         * Render settings page.
+         */
+        public function render_settings_page() {
+            ?>
+            <div class="wrap">
+                <h1><?php esc_html_e( 'Wood House Designer Settings', 'wood-house-designer' ); ?></h1>
+                <form action="options.php" method="post">
+                    <?php
+                    settings_fields( 'wood_house_designer_settings' );
+                    do_settings_sections( 'wood_house_designer_settings' );
+                    submit_button();
+                    ?>
+                </form>
+            </div>
+            <?php
+        }
+
+        /**
+         * Retrieve saved options.
+         *
+         * @return array<string, mixed>
+         */
+        public function get_options() {
+            $options = get_option( self::OPTION_KEY, array() );
+
+            return wp_parse_args( $options, $this->get_defaults() );
+        }
+
+        /**
+         * Get default values.
+         *
+         * @return array<string, mixed>
+         */
+        public function get_defaults() {
+            return $this->defaults;
+        }
+    }
+}

--- a/wp-content/plugins/wood-house-designer/includes/class-wood-house-designer-template-loader.php
+++ b/wp-content/plugins/wood-house-designer/includes/class-wood-house-designer-template-loader.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Page template loader for Wood House Designer.
+ *
+ * @package WoodHouseDesigner
+ */
+
+if ( ! class_exists( 'Wood_House_Designer_Template_Loader' ) ) {
+    /**
+     * Template loader utility.
+     */
+    class Wood_House_Designer_Template_Loader {
+        /**
+         * Singleton instance.
+         *
+         * @var Wood_House_Designer_Template_Loader
+         */
+        protected static $instance = null;
+
+        /**
+         * Template slug.
+         */
+        const TEMPLATE_SLUG = 'wood-house-designer-template.php';
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @return Wood_House_Designer_Template_Loader
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        private function __construct() {
+            add_filter( 'theme_page_templates', array( $this, 'add_page_template' ) );
+            add_filter( 'template_include', array( $this, 'load_template' ) );
+        }
+
+        /**
+         * Register template in page template dropdown.
+         *
+         * @param array $templates Available templates.
+         *
+         * @return array
+         */
+        public function add_page_template( $templates ) {
+            $templates[ self::TEMPLATE_SLUG ] = __( 'Wood House Designer App', 'wood-house-designer' );
+
+            return $templates;
+        }
+
+        /**
+         * Load plugin template when selected.
+         *
+         * @param string $template Path to template.
+         *
+         * @return string
+         */
+        public function load_template( $template ) {
+            if ( is_singular() ) {
+                $chosen_template = get_page_template_slug();
+                if ( self::TEMPLATE_SLUG === $chosen_template ) {
+                    $plugin_template = WOOD_HOUSE_DESIGNER_PATH . 'templates/' . self::TEMPLATE_SLUG;
+                    if ( file_exists( $plugin_template ) ) {
+                        return $plugin_template;
+                    }
+                }
+            }
+
+            return $template;
+        }
+    }
+}

--- a/wp-content/plugins/wood-house-designer/templates/wood-house-designer-template.php
+++ b/wp-content/plugins/wood-house-designer/templates/wood-house-designer-template.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Template file for Wood House Designer app.
+ *
+ * @package WoodHouseDesigner
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+get_header();
+?>
+<main id="primary" class="site-main wood-house-designer-template">
+    <?php
+    while ( have_posts() ) {
+        the_post();
+        the_content();
+        echo do_shortcode( '[wood_house_designer]' );
+    }
+    ?>
+</main>
+<?php
+get_footer();

--- a/wp-content/plugins/wood-house-designer/wood-house-designer.php
+++ b/wp-content/plugins/wood-house-designer/wood-house-designer.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Wood House Designer
+ * Description: Configurable interactive wood house design tool with Konva.js integration.
+ * Version: 1.0.0
+ * Author: ArchiWood Team
+ * Text Domain: wood-house-designer
+ * Domain Path: /languages
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'WOOD_HOUSE_DESIGNER_VERSION', '1.0.0' );
+define( 'WOOD_HOUSE_DESIGNER_PATH', plugin_dir_path( __FILE__ ) );
+define( 'WOOD_HOUSE_DESIGNER_URL', plugin_dir_url( __FILE__ ) );
+define( 'WOOD_HOUSE_DESIGNER_BASENAME', plugin_basename( __FILE__ ) );
+
+require_once WOOD_HOUSE_DESIGNER_PATH . 'includes/class-wood-house-designer.php';
+require_once WOOD_HOUSE_DESIGNER_PATH . 'includes/class-wood-house-designer-settings.php';
+require_once WOOD_HOUSE_DESIGNER_PATH . 'includes/class-wood-house-designer-template-loader.php';
+
+Wood_House_Designer::instance();
+Wood_House_Designer_Settings::instance();
+Wood_House_Designer_Template_Loader::instance();


### PR DESCRIPTION
## Summary
- add the Wood House Designer plugin bootstrap and initialize core classes
- implement shortcode rendering, assets, Konva.js app logic, and responsive styles
- provide admin settings, page template loader, and usage documentation in the README

## Testing
- find wp-content/plugins/wood-house-designer -name "*.php" -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68cbb170c09883328eb638d850796f92