### PR TITLE
Integrate React-based interface for wood house designer

### DIFF
--- a/wp-content/plugins/wood-house-designer/assets/js/app.js
+++ b/wp-content/plugins/wood-house-designer/assets/js/app.js
@@ -1,196 +1,53 @@
-(function () {
+(function (wp) {
     'use strict';
 
-    const config = window.WoodHouseDesignerConfig || {};
-
-    function initApp() {
-        const container = document.getElementById('whd-stage-container');
-        if (!container || typeof Konva === 'undefined') {
-            return;
-        }
-
-        const shapesList = document.getElementById('whd-shape-list');
-        const exportBtn = document.getElementById('whd-export-project');
-
-        if (!shapesList) {
-            return;
-        }
-
-        const width = config.canvasWidth || container.clientWidth || 1000;
-        const height = config.canvasHeight || container.clientHeight || 600;
-        const gridSize = config.gridSize || 50;
-        const scaleRatio = config.scaleRatio || 1;
-
-        container.style.minHeight = height + 'px';
-
-        const stage = new Konva.Stage({
-            container: 'whd-stage-container',
-            width,
-            height
-        });
-
-        const gridLayer = new Konva.Layer({ listening: false });
-        const drawingLayer = new Konva.Layer();
-
-        stage.add(gridLayer);
-        stage.add(drawingLayer);
-
-        let stageWidth = width;
-        let stageHeight = height;
-
-        function resizeStage() {
-            const containerWidth = container.clientWidth || stageWidth;
-            const containerHeight = container.clientHeight || stageHeight;
-            stageWidth = containerWidth || width;
-            stageHeight = containerHeight || height;
-            stage.size({ width: stageWidth, height: stageHeight });
-            drawGrid(gridLayer, stageWidth, stageHeight, gridSize, scaleRatio);
-        }
-
-        window.addEventListener('resize', function () {
-            clearTimeout(window.__whdResizeTimer);
-            window.__whdResizeTimer = setTimeout(resizeStage, 150);
-        });
-
-        resizeStage();
-        updateStatus('Ready. Use the toolbox to add elements.');
-
-        const transformer = new Konva.Transformer({
-            rotateEnabled: true,
-            enabledAnchors: [
-                'top-left', 'top-center', 'top-right',
-                'middle-left', 'middle-right',
-                'bottom-left', 'bottom-center', 'bottom-right'
-            ]
-        });
-        drawingLayer.add(transformer);
-
-        stage.on('click tap', function (evt) {
-            if (evt.target === stage) {
-                transformer.nodes([]);
-                updateStatus('');
-                return;
-            }
-
-            if (!evt.target.draggable()) {
-                return;
-            }
-
-            transformer.nodes([evt.target]);
-            const dims = getDimensions(evt.target, scaleRatio);
-            updateStatus(`${dims}`);
-        });
-
-        stage.on('mousemove', function () {
-            const pointer = stage.getPointerPosition();
-            if (!pointer) {
-                return;
-            }
-            const activeNodes = transformer.nodes();
-            if (activeNodes.length > 0) {
-                return;
-            }
-            const scaledX = (pointer.x / gridSize * scaleRatio).toFixed(2);
-            const scaledY = (pointer.y / gridSize * scaleRatio).toFixed(2);
-            updateStatus(`Cursor: ${scaledX} × ${scaledY} m`);
-        });
-
-        const tools = getToolsConfig(scaleRatio);
-        tools.forEach(function (tool) {
-            const button = document.createElement('button');
-            button.className = 'whd-tool-button';
-            button.type = 'button';
-            button.textContent = tool.label;
-            button.addEventListener('click', function () {
-                const node = tool.factory({ gridSize, scaleRatio });
-                node.on('dragmove transform', function () {
-                    updateDimensionLabel(node, scaleRatio);
-                    if (transformer.nodes().includes(node)) {
-                        const dims = getDimensions(node, scaleRatio);
-                        updateStatus(`${dims}`);
-                    }
-                });
-                drawingLayer.add(node);
-                drawingLayer.draw();
-                transformer.nodes([node]);
-                const dims = getDimensions(node, scaleRatio);
-                updateStatus(`${dims}`);
-            });
-            shapesList.appendChild(button);
-        });
-
-        if (exportBtn) {
-            exportBtn.addEventListener('click', function () {
-                const json = stage.toJSON();
-                const metadata = {
-                    version: config.appVersion || '1.0.0',
-                    generatedAt: new Date().toISOString(),
-                    scaleRatio,
-                    gridSize,
-                    canvas: { width, height }
-                };
-                const payload = JSON.stringify({ metadata, stage: JSON.parse(json) }, null, 2);
-                downloadFile((config.exportFileName || 'wood-house-project') + '.json', payload);
-                updateStatus('Project exported successfully.');
-            });
-        }
+    if (!wp || !wp.element) {
+        return;
     }
 
-    function drawGrid(layer, width, height, gridSize, scaleRatio) {
-        layer.destroyChildren();
-        const elements = [];
-        const majorEvery = 5;
-        const majorColor = '#a0aec0';
-        const minorColor = '#e2e8f0';
+    const { createElement: el, render, useCallback, useEffect, useRef, useState } = wp.element;
 
-        for (let i = 0; i <= width / gridSize; i++) {
-            const isMajor = i % majorEvery === 0;
-            elements.push(new Konva.Line({
-                points: [i * gridSize, 0, i * gridSize, height],
-                stroke: isMajor ? majorColor : minorColor,
-                strokeWidth: isMajor ? 1 : 0.5
-            }));
-            if (isMajor && i > 0) {
-                elements.push(new Konva.Text({
-                    x: i * gridSize + 4,
-                    y: 4,
-                    text: `${(i * scaleRatio).toFixed(2)} m`,
-                    fontSize: 10,
-                    fill: '#4a5568'
-                }));
-            }
-        }
+    const DEFAULT_STRINGS = {
+        appTitle: 'Wood House Designer',
+        shapesHeading: 'Shapes',
+        actionsHeading: 'Actions',
+        exportButton: 'Export Project',
+        ready: 'Ready. Use the toolbox to add elements.',
+        exportSuccess: 'Project exported successfully.',
+        exportUnavailable: 'Unable to export the project right now.',
+        errorKonva: 'The drawing library is not available. Please refresh the page.',
+        cursorStatus: 'Cursor: %x% × %y% m',
+        selectedStatus: 'Selected %name% - %width%m × %height%m',
+        toolWall: 'Wall (Rectangle)',
+        toolWindow: 'Window (Circle)',
+        toolBeam: 'Beam (Line)',
+        toolDimension: 'Dimension Label',
+        designCanvas: 'Design Canvas',
+        toolbox: 'Toolbox'
+    };
 
-        for (let j = 0; j <= height / gridSize; j++) {
-            const isMajor = j % majorEvery === 0;
-            elements.push(new Konva.Line({
-                points: [0, j * gridSize, width, j * gridSize],
-                stroke: isMajor ? majorColor : minorColor,
-                strokeWidth: isMajor ? 1 : 0.5
-            }));
-            if (isMajor && j > 0) {
-                elements.push(new Konva.Text({
-                    x: 4,
-                    y: j * gridSize + 4,
-                    text: `${(j * scaleRatio).toFixed(2)} m`,
-                    fontSize: 10,
-                    fill: '#4a5568'
-                }));
-            }
-        }
+    function buildConfig(config) {
+        const normalized = config || {};
+        const strings = Object.assign({}, DEFAULT_STRINGS, normalized.strings || {});
 
-        elements.forEach(function (item) {
-            layer.add(item);
-        });
-
-        layer.draw();
+        return {
+            gridSize: normalized.gridSize && normalized.gridSize > 0 ? normalized.gridSize : 50,
+            scaleRatio: normalized.scaleRatio && normalized.scaleRatio > 0 ? normalized.scaleRatio : 1,
+            canvasWidth: normalized.canvasWidth || 0,
+            canvasHeight: normalized.canvasHeight || 0,
+            exportFileName: normalized.exportFileName || 'wood-house-project',
+            appVersion: normalized.appVersion || '1.0.0',
+            strings: strings
+        };
     }
 
-    function getToolsConfig(scaleRatio) {
+    function getToolsConfig(config) {
         return [
             {
-                label: 'Wall (Rectangle)',
-                factory: function ({ gridSize }) {
+                id: 'wall',
+                label: config.strings.toolWall,
+                factory: function (options) {
+                    const gridSize = options.gridSize;
                     return new Konva.Rect({
                         x: gridSize * 2,
                         y: gridSize * 2,
@@ -205,8 +62,10 @@
                 }
             },
             {
-                label: 'Window (Circle)',
-                factory: function ({ gridSize }) {
+                id: 'window',
+                label: config.strings.toolWindow,
+                factory: function (options) {
+                    const gridSize = options.gridSize;
                     return new Konva.Circle({
                         x: gridSize * 3,
                         y: gridSize * 3,
@@ -220,8 +79,10 @@
                 }
             },
             {
-                label: 'Beam (Line)',
-                factory: function ({ gridSize }) {
+                id: 'beam',
+                label: config.strings.toolBeam,
+                factory: function (options) {
+                    const gridSize = options.gridSize;
                     return new Konva.Line({
                         points: [gridSize, gridSize, gridSize * 4, gridSize * 2],
                         stroke: '#805ad5',
@@ -234,8 +95,10 @@
                 }
             },
             {
-                label: 'Dimension Label',
-                factory: function ({ gridSize, scaleRatio }) {
+                id: 'dimension',
+                label: config.strings.toolDimension,
+                factory: function (options) {
+                    const gridSize = options.gridSize;
                     const group = new Konva.Group({
                         x: gridSize * 2,
                         y: gridSize * 4,
@@ -262,45 +125,110 @@
                     group.add(line);
                     group.add(text);
 
-                    group.on('dragmove transform', function () {
-                        updateDimensionLabel(group, scaleRatio);
-                    });
-
-                    updateDimensionLabel(group, scaleRatio);
-
                     return group;
                 }
             }
         ];
     }
 
-    function getDimensions(node, scaleRatio) {
+    function drawGrid(layer, width, height, gridSize, scaleRatio) {
+        layer.destroyChildren();
+
+        const elements = [];
+        const majorEvery = 5;
+        const majorColor = '#a0aec0';
+        const minorColor = '#e2e8f0';
+
+        for (let i = 0; i <= width / gridSize; i++) {
+            const isMajor = i % majorEvery === 0;
+            elements.push(new Konva.Line({
+                points: [i * gridSize, 0, i * gridSize, height],
+                stroke: isMajor ? majorColor : minorColor,
+                strokeWidth: isMajor ? 1 : 0.5
+            }));
+
+            if (isMajor && i > 0) {
+                elements.push(new Konva.Text({
+                    x: i * gridSize + 4,
+                    y: 4,
+                    text: (i * scaleRatio).toFixed(2) + ' m',
+                    fontSize: 10,
+                    fill: '#4a5568'
+                }));
+            }
+        }
+
+        for (let j = 0; j <= height / gridSize; j++) {
+            const isMajor = j % majorEvery === 0;
+            elements.push(new Konva.Line({
+                points: [0, j * gridSize, width, j * gridSize],
+                stroke: isMajor ? majorColor : minorColor,
+                strokeWidth: isMajor ? 1 : 0.5
+            }));
+
+            if (isMajor && j > 0) {
+                elements.push(new Konva.Text({
+                    x: 4,
+                    y: j * gridSize + 4,
+                    text: (j * scaleRatio).toFixed(2) + ' m',
+                    fontSize: 10,
+                    fill: '#4a5568'
+                }));
+            }
+        }
+
+        for (let index = 0; index < elements.length; index++) {
+            layer.add(elements[index]);
+        }
+
+        layer.draw();
+    }
+
+    function formatTemplate(template, replacements) {
+        if (typeof template !== 'string') {
+            return '';
+        }
+
+        return Object.keys(replacements).reduce(function (result, key) {
+            const value = replacements[key];
+            const pattern = new RegExp('%' + key + '%', 'g');
+            return result.replace(pattern, value);
+        }, template);
+    }
+
+    function getDimensions(node, config) {
+        if (!node || typeof node.getClientRect !== 'function') {
+            return '';
+        }
+
         const box = node.getClientRect({ skipShadow: true, skipStroke: false });
-        const widthMeters = (box.width / getGridSize() * scaleRatio).toFixed(2);
-        const heightMeters = (box.height / getGridSize() * scaleRatio).toFixed(2);
-        return `Selected ${node.name() || node.className} - ${widthMeters}m x ${heightMeters}m`;
+        const gridSize = config.gridSize || 50;
+        const scaleRatio = config.scaleRatio || 1;
+        const widthMeters = (box.width / gridSize * scaleRatio).toFixed(2);
+        const heightMeters = (box.height / gridSize * scaleRatio).toFixed(2);
+        const rawName = typeof node.name === 'function' && node.name() ? node.name() : node.className || 'shape';
+        const formattedName = rawName.charAt(0).toUpperCase() + rawName.slice(1);
 
-        function getGridSize() {
-            return config.gridSize || 50;
-        }
+        return formatTemplate(config.strings.selectedStatus, {
+            name: formattedName,
+            width: widthMeters,
+            height: heightMeters
+        });
     }
 
-    function updateStatus(message) {
-        const statusEl = document.getElementById('whd-status-message');
-        if (statusEl) {
-            statusEl.textContent = message;
-        }
-    }
-
-    function updateDimensionLabel(node, scaleRatio) {
+    function updateDimensionLabel(node, config) {
         if (!node || typeof node.name !== 'function' || node.name() !== 'dimension') {
             return;
         }
+
         const box = node.getClientRect({ skipShadow: true, skipStroke: false });
-        const widthMeters = (box.width / (config.gridSize || 50) * scaleRatio).toFixed(2);
+        const gridSize = config.gridSize || 50;
+        const scaleRatio = config.scaleRatio || 1;
+        const widthMeters = (box.width / gridSize * scaleRatio).toFixed(2);
         const textNode = node.findOne('Text');
+
         if (textNode) {
-            textNode.text(`${widthMeters} m`);
+            textNode.text(widthMeters + ' m');
             textNode.offsetX(textNode.width() / 2);
         }
     }
@@ -318,9 +246,302 @@
         }, 2000);
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initApp);
-    } else {
-        initApp();
+    function WoodHouseDesignerApp(props) {
+        const configRef = useRef(buildConfig(props.initialConfig));
+        const config = configRef.current;
+        const toolsRef = useRef(getToolsConfig(config));
+        const tools = toolsRef.current;
+
+        const stageContainerRef = useRef(null);
+        const stageRef = useRef(null);
+        const drawingLayerRef = useRef(null);
+        const gridLayerRef = useRef(null);
+        const transformerRef = useRef(null);
+        const resizeTimerRef = useRef(null);
+        const statusRef = useRef('');
+
+        const [status, setStatus] = useState('');
+
+        const updateStatus = useCallback(function (message) {
+            if (statusRef.current === message) {
+                return;
+            }
+
+            statusRef.current = message;
+            setStatus(message);
+        }, []);
+
+        useEffect(function () {
+            const container = stageContainerRef.current;
+            if (!container) {
+                return undefined;
+            }
+
+            if (typeof Konva === 'undefined') {
+                updateStatus(config.strings.errorKonva);
+                return undefined;
+            }
+
+            const width = config.canvasWidth || container.clientWidth || 1000;
+            const height = config.canvasHeight || container.clientHeight || 600;
+
+            container.style.minHeight = height + 'px';
+
+            const stage = new Konva.Stage({
+                container: container,
+                width: width,
+                height: height
+            });
+            stageRef.current = stage;
+
+            const gridLayer = new Konva.Layer({ listening: false });
+            const drawingLayer = new Konva.Layer();
+
+            stage.add(gridLayer);
+            stage.add(drawingLayer);
+
+            gridLayerRef.current = gridLayer;
+            drawingLayerRef.current = drawingLayer;
+
+            const transformer = new Konva.Transformer({
+                rotateEnabled: true,
+                enabledAnchors: [
+                    'top-left', 'top-center', 'top-right',
+                    'middle-left', 'middle-right',
+                    'bottom-left', 'bottom-center', 'bottom-right'
+                ]
+            });
+
+            drawingLayer.add(transformer);
+            transformerRef.current = transformer;
+
+            function resizeStage() {
+                const containerWidth = container.clientWidth || width;
+                const containerHeight = container.clientHeight || height;
+                stage.size({
+                    width: containerWidth || width,
+                    height: containerHeight || height
+                });
+                drawGrid(gridLayer, stage.width(), stage.height(), config.gridSize, config.scaleRatio);
+            }
+
+            const handleResize = function () {
+                if (resizeTimerRef.current) {
+                    clearTimeout(resizeTimerRef.current);
+                }
+                resizeTimerRef.current = setTimeout(resizeStage, 150);
+            };
+
+            const handleStageClick = function (evt) {
+                if (evt.target === stage) {
+                    transformer.nodes([]);
+                    updateStatus('');
+                    return;
+                }
+
+                if (!evt.target.draggable()) {
+                    return;
+                }
+
+                transformer.nodes([evt.target]);
+                updateStatus(getDimensions(evt.target, config));
+            };
+
+            const handleStageMouseMove = function () {
+                const pointer = stage.getPointerPosition();
+                if (!pointer) {
+                    return;
+                }
+
+                if (transformer.nodes().length > 0) {
+                    return;
+                }
+
+                const scaledX = (pointer.x / config.gridSize * config.scaleRatio).toFixed(2);
+                const scaledY = (pointer.y / config.gridSize * config.scaleRatio).toFixed(2);
+                updateStatus(formatTemplate(config.strings.cursorStatus, {
+                    x: scaledX,
+                    y: scaledY
+                }));
+            };
+
+            window.addEventListener('resize', handleResize);
+            stage.on('click tap', handleStageClick);
+            stage.on('mousemove', handleStageMouseMove);
+
+            resizeStage();
+            updateStatus(config.strings.ready);
+
+            return function () {
+                window.removeEventListener('resize', handleResize);
+                stage.off('click tap', handleStageClick);
+                stage.off('mousemove', handleStageMouseMove);
+
+                if (resizeTimerRef.current) {
+                    clearTimeout(resizeTimerRef.current);
+                }
+
+                if (transformerRef.current) {
+                    transformerRef.current.destroy();
+                    transformerRef.current = null;
+                }
+
+                if (gridLayerRef.current) {
+                    gridLayerRef.current.destroy();
+                    gridLayerRef.current = null;
+                }
+
+                if (drawingLayerRef.current) {
+                    drawingLayerRef.current.destroy();
+                    drawingLayerRef.current = null;
+                }
+
+                if (stageRef.current) {
+                    stageRef.current.destroy();
+                    stageRef.current = null;
+                }
+            };
+        }, [config, updateStatus]);
+
+        const handleToolClick = useCallback(function (tool) {
+            if (!drawingLayerRef.current || !transformerRef.current) {
+                return;
+            }
+
+            const node = tool.factory({
+                gridSize: config.gridSize,
+                scaleRatio: config.scaleRatio
+            });
+
+            node.on('dragmove transform', function () {
+                updateDimensionLabel(node, config);
+                if (transformerRef.current && transformerRef.current.nodes().includes(node)) {
+                    updateStatus(getDimensions(node, config));
+                }
+            });
+
+            if (drawingLayerRef.current) {
+                drawingLayerRef.current.add(node);
+                drawingLayerRef.current.draw();
+            }
+
+            if (transformerRef.current) {
+                transformerRef.current.nodes([node]);
+            }
+
+            updateDimensionLabel(node, config);
+            updateStatus(getDimensions(node, config));
+        }, [config, updateStatus]);
+
+        const handleExport = useCallback(function () {
+            if (!stageRef.current) {
+                updateStatus(config.strings.exportUnavailable);
+                return;
+            }
+
+            const stage = stageRef.current;
+            const json = stage.toJSON();
+            const metadata = {
+                version: config.appVersion,
+                generatedAt: new Date().toISOString(),
+                scaleRatio: config.scaleRatio,
+                gridSize: config.gridSize,
+                canvas: {
+                    width: stage.width(),
+                    height: stage.height()
+                }
+            };
+
+            const payload = JSON.stringify({
+                metadata: metadata,
+                stage: JSON.parse(json)
+            }, null, 2);
+
+            downloadFile((config.exportFileName || 'wood-house-project') + '.json', payload);
+            updateStatus(config.strings.exportSuccess);
+        }, [config, updateStatus]);
+
+        return el(
+            'div',
+            { className: 'whd-app', 'data-app-version': config.appVersion },
+            el(
+                'div',
+                { className: 'whd-header' },
+                el('h1', { className: 'whd-header__title' }, config.strings.appTitle)
+            ),
+            el(
+                'div',
+                { className: 'whd-body' },
+                el(
+                    'aside',
+                    { className: 'whd-tools', 'aria-label': config.strings.toolbox },
+                    el(
+                        'div',
+                        { className: 'whd-tools__section' },
+                        el('h2', { className: 'whd-tools__title' }, config.strings.shapesHeading),
+                        el(
+                            'ul',
+                            { className: 'whd-tools__list' },
+                            tools.map(function (tool) {
+                                return el(
+                                    'li',
+                                    { key: tool.id },
+                                    el(
+                                        'button',
+                                        {
+                                            type: 'button',
+                                            className: 'whd-tool-button',
+                                            onClick: function () {
+                                                handleToolClick(tool);
+                                            }
+                                        },
+                                        tool.label
+                                    )
+                                );
+                            })
+                        )
+                    ),
+                    el(
+                        'div',
+                        { className: 'whd-tools__section' },
+                        el('h2', { className: 'whd-tools__title' }, config.strings.actionsHeading),
+                        el(
+                            'button',
+                            {
+                                className: 'button button-primary',
+                                type: 'button',
+                                onClick: handleExport
+                            },
+                            config.strings.exportButton
+                        )
+                    )
+                ),
+                el(
+                    'main',
+                    { className: 'whd-canvas', 'aria-label': config.strings.designCanvas },
+                    el('div', {
+                        id: 'whd-stage-container',
+                        className: 'whd-canvas__stage',
+                        role: 'application',
+                        'aria-live': 'polite',
+                        ref: stageContainerRef
+                    })
+                )
+            ),
+            el(
+                'footer',
+                { className: 'whd-status', role: 'status', 'aria-live': 'polite' },
+                el('span', null, status)
+            )
+        );
     }
-})();
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const root = document.getElementById('whd-app-root');
+        if (!root) {
+            return;
+        }
+
+        render(el(WoodHouseDesignerApp, { initialConfig: window.WoodHouseDesignerConfig || {} }), root);
+    });
+})(window.wp);

--- a/wp-content/plugins/wood-house-designer/includes/class-wood-house-designer.php
+++ b/wp-content/plugins/wood-house-designer/includes/class-wood-house-designer.php
@@ -61,30 +61,15 @@ if ( ! class_exists( 'Wood_House_Designer' ) ) {
         public function render_app() {
             ob_start();
             ?>
-            <div class="whd-app" id="whd-app" data-app-version="<?php echo esc_attr( WOOD_HOUSE_DESIGNER_VERSION ); ?>">
-                <div class="whd-header">
-                    <h1 class="whd-header__title"><?php esc_html_e( 'Wood House Designer', 'wood-house-designer' ); ?></h1>
+            <div id="whd-app-root">
+                <div class="whd-app whd-app--loading" data-app-version="<?php echo esc_attr( WOOD_HOUSE_DESIGNER_VERSION ); ?>">
+                    <div class="whd-header">
+                        <h1 class="whd-header__title"><?php esc_html_e( 'Wood House Designer', 'wood-house-designer' ); ?></h1>
+                    </div>
+                    <div class="whd-body">
+                        <p><?php esc_html_e( 'Loading application…', 'wood-house-designer' ); ?></p>
+                    </div>
                 </div>
-                <div class="whd-body">
-                    <aside class="whd-tools" aria-label="<?php esc_attr_e( 'Toolbox', 'wood-house-designer' ); ?>">
-                        <div class="whd-tools__section">
-                            <h2 class="whd-tools__title"><?php esc_html_e( 'Shapes', 'wood-house-designer' ); ?></h2>
-                            <ul class="whd-tools__list" id="whd-shape-list"></ul>
-                        </div>
-                        <div class="whd-tools__section">
-                            <h2 class="whd-tools__title"><?php esc_html_e( 'Actions', 'wood-house-designer' ); ?></h2>
-                            <button class="button button-primary" id="whd-export-project" type="button">
-                                <?php esc_html_e( 'Export Project', 'wood-house-designer' ); ?>
-                            </button>
-                        </div>
-                    </aside>
-                    <main class="whd-canvas" aria-label="<?php esc_attr_e( 'Design Canvas', 'wood-house-designer' ); ?>">
-                        <div id="whd-stage-container" class="whd-canvas__stage" role="application" aria-live="polite"></div>
-                    </main>
-                </div>
-                <footer class="whd-status" role="status" aria-live="polite">
-                    <span id="whd-status-message"></span>
-                </footer>
             </div>
             <?php
 
@@ -117,7 +102,7 @@ if ( ! class_exists( 'Wood_House_Designer' ) ) {
             wp_enqueue_script(
                 'wood-house-designer',
                 WOOD_HOUSE_DESIGNER_URL . 'assets/js/app.js',
-                array( 'konva' ),
+                array( 'konva', 'wp-element' ),
                 WOOD_HOUSE_DESIGNER_VERSION,
                 true
             );
@@ -134,6 +119,24 @@ if ( ! class_exists( 'Wood_House_Designer' ) ) {
                     'canvasHeight'   => (int) $options['canvas_height'],
                     'exportFileName' => sanitize_file_name( $options['export_file_name'] ),
                     'appVersion'     => WOOD_HOUSE_DESIGNER_VERSION,
+                    'strings'        => array(
+                        'appTitle'         => esc_html__( 'Wood House Designer', 'wood-house-designer' ),
+                        'shapesHeading'    => esc_html__( 'Shapes', 'wood-house-designer' ),
+                        'actionsHeading'   => esc_html__( 'Actions', 'wood-house-designer' ),
+                        'exportButton'     => esc_html__( 'Export Project', 'wood-house-designer' ),
+                        'ready'            => esc_html__( 'Ready. Use the toolbox to add elements.', 'wood-house-designer' ),
+                        'exportSuccess'    => esc_html__( 'Project exported successfully.', 'wood-house-designer' ),
+                        'exportUnavailable'=> esc_html__( 'Unable to export the project right now.', 'wood-house-designer' ),
+                        'errorKonva'       => esc_html__( 'The drawing library is not available. Please refresh the page.', 'wood-house-designer' ),
+                        'cursorStatus'     => esc_html__( 'Cursor: %x% × %y% m', 'wood-house-designer' ),
+                        'selectedStatus'   => esc_html__( 'Selected %name% - %width%m × %height%m', 'wood-house-designer' ),
+                        'toolWall'         => esc_html__( 'Wall (Rectangle)', 'wood-house-designer' ),
+                        'toolWindow'       => esc_html__( 'Window (Circle)', 'wood-house-designer' ),
+                        'toolBeam'         => esc_html__( 'Beam (Line)', 'wood-house-designer' ),
+                        'toolDimension'    => esc_html__( 'Dimension Label', 'wood-house-designer' ),
+                        'designCanvas'     => esc_html__( 'Design Canvas', 'wood-house-designer' ),
+                        'toolbox'          => esc_html__( 'Toolbox', 'wood-house-designer' ),
+                    ),
                 )
             );
         }


### PR DESCRIPTION
## Summary
- replace the shortcode output with a React mount point and expose UI strings through localized configuration
- rebuild the front-end app as a React component driven by wp.element, keeping Konva integrations and export logic intact

## Testing
- php -l wp-content/plugins/wood-house-designer/includes/class-wood-house-designer.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb510310c8332acfd288d92058b38