### PR TITLE
Add isometric view toggle and 3D cottage rendering

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -18,6 +18,7 @@
     padding: 0.75rem;
     border: 1px solid #d7d7d7;
     border-radius: 4px;
+    flex-wrap: wrap;
 }
 
 .whd-casetta-field {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -23,14 +23,45 @@
     color: #fff;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     padding: 0 1.5rem;
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+    gap: 1rem;
 }
 
 .whd-header__title {
     font-size: 1.25rem;
     margin: 0;
     letter-spacing: 0.05em;
+}
+
+.whd-view-toggle {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.whd-view-toggle__button {
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.whd-view-toggle__button:hover,
+.whd-view-toggle__button:focus {
+    background: rgba(255, 255, 255, 0.25);
+    outline: none;
+}
+
+.whd-view-toggle__button--active {
+    background: #fff;
+    color: var(--whd-primary);
+    border-color: #fff;
 }
 
 .whd-body {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -17,12 +17,268 @@
         exportUnavailable: 'Unable to export the project right now.',
         errorKonva: 'The drawing library is not available. Please refresh the page.',
         cursorStatus: 'Cursor: %x% × %y% m',
-        selectedStatus: 'Selected %name% - %width%m × %height%m',
-        cottageLabel: 'Cottage %width%m × %depth%m',
+        selectedStatus: 'Selected %name% - %width%m × %depth%m × %height%m',
+        cottageLabel: 'Cottage %width%m × %depth%m × %height%m',
         noCottages: 'No cottages configured yet.',
         designCanvas: 'Design Canvas',
-        toolbox: 'Toolbox'
+        toolbox: 'Toolbox',
+        viewTop: 'Top View',
+        viewIso: 'Isometric View',
+        viewToggleLabel: 'View mode',
+        isoViewStatus: 'Isometric view active.'
     };
+
+    const ISO_ANGLE = Math.PI / 6;
+    const ISO_COS = Math.cos(ISO_ANGLE);
+    const ISO_SIN = Math.sin(ISO_ANGLE);
+
+    function projectIsometric(x, y, z) {
+        return {
+            x: (x - y) * ISO_COS,
+            y: (x + y) * ISO_SIN - z
+        };
+    }
+
+    function buildIsometricGeometry(widthPx, depthPx, heightPx) {
+        const corners = {
+            backLeftBottom: projectIsometric(0, 0, 0),
+            backRightBottom: projectIsometric(widthPx, 0, 0),
+            frontLeftBottom: projectIsometric(0, depthPx, 0),
+            frontRightBottom: projectIsometric(widthPx, depthPx, 0),
+            backLeftTop: projectIsometric(0, 0, heightPx),
+            backRightTop: projectIsometric(widthPx, 0, heightPx),
+            frontLeftTop: projectIsometric(0, depthPx, heightPx),
+            frontRightTop: projectIsometric(widthPx, depthPx, heightPx)
+        };
+
+        const shiftX = -corners.frontLeftBottom.x;
+        const shiftY = -corners.frontLeftBottom.y;
+
+        const shifted = {};
+        Object.keys(corners).forEach(function (key) {
+            shifted[key] = {
+                x: corners[key].x + shiftX,
+                y: corners[key].y + shiftY
+            };
+        });
+
+        const minY = Math.min.apply(null, Object.keys(shifted).map(function (key) {
+            return shifted[key].y;
+        }));
+
+        const extraY = minY < 0 ? -minY : 0;
+        Object.keys(shifted).forEach(function (key) {
+            shifted[key].y += extraY;
+        });
+
+        const baseY = shifted.frontLeftBottom.y;
+        Object.keys(shifted).forEach(function (key) {
+            shifted[key].y -= baseY;
+        });
+
+        return {
+            top: [
+                shifted.backLeftTop.x, shifted.backLeftTop.y,
+                shifted.backRightTop.x, shifted.backRightTop.y,
+                shifted.frontRightTop.x, shifted.frontRightTop.y,
+                shifted.frontLeftTop.x, shifted.frontLeftTop.y
+            ],
+            left: [
+                shifted.backLeftTop.x, shifted.backLeftTop.y,
+                shifted.frontLeftTop.x, shifted.frontLeftTop.y,
+                shifted.frontLeftBottom.x, shifted.frontLeftBottom.y,
+                shifted.backLeftBottom.x, shifted.backLeftBottom.y
+            ],
+            right: [
+                shifted.backRightTop.x, shifted.backRightTop.y,
+                shifted.frontRightTop.x, shifted.frontRightTop.y,
+                shifted.frontRightBottom.x, shifted.frontRightBottom.y,
+                shifted.backRightBottom.x, shifted.backRightBottom.y
+            ],
+            outline: [
+                shifted.backLeftTop.x, shifted.backLeftTop.y,
+                shifted.backRightTop.x, shifted.backRightTop.y,
+                shifted.frontRightTop.x, shifted.frontRightTop.y,
+                shifted.frontRightBottom.x, shifted.frontRightBottom.y,
+                shifted.frontLeftBottom.x, shifted.frontLeftBottom.y,
+                shifted.frontLeftTop.x, shifted.frontLeftTop.y,
+                shifted.backLeftTop.x, shifted.backLeftTop.y,
+                shifted.backLeftBottom.x, shifted.backLeftBottom.y,
+                shifted.backRightBottom.x, shifted.backRightBottom.y
+            ]
+        };
+    }
+
+    function applyViewModeToNode(node, mode) {
+        if (!node || typeof node.findOne !== 'function') {
+            return;
+        }
+
+        const topView = node.findOne('.whd-top-view');
+        const isoView = node.findOne('.whd-iso-view');
+
+        if (topView) {
+            topView.visible(mode === 'top');
+        }
+
+        if (isoView) {
+            isoView.visible(mode === 'iso');
+        }
+    }
+
+    function updateIsometricGeometry(node, options) {
+        if (!node || typeof node.findOne !== 'function') {
+            return;
+        }
+
+        const config = options || {};
+        const dimensions = node.getAttr('whdDimensions');
+        if (!dimensions) {
+            return;
+        }
+
+        const scaleRatio = config.scaleRatio && config.scaleRatio > 0 ? config.scaleRatio : 1;
+        const pixelsPerMeter = (config.gridSize || 50) / scaleRatio;
+        const widthPx = dimensions.widthMeters * pixelsPerMeter;
+        const depthPx = dimensions.depthMeters * pixelsPerMeter;
+        const heightPx = dimensions.heightMeters * pixelsPerMeter;
+
+        node.setAttr('whdPixelSize', {
+            widthPx: widthPx,
+            depthPx: depthPx,
+            heightPx: heightPx
+        });
+
+        const topRect = node.findOne('.whd-top-rect');
+        if (topRect) {
+            topRect.size({ width: widthPx, height: depthPx });
+        }
+
+        const isoGroup = node.findOne('.whd-iso-view');
+        if (!isoGroup) {
+            return;
+        }
+
+        const geometry = buildIsometricGeometry(widthPx, depthPx, heightPx);
+        const topFace = isoGroup.findOne('.whd-iso-top');
+        const leftFace = isoGroup.findOne('.whd-iso-left');
+        const rightFace = isoGroup.findOne('.whd-iso-right');
+        const outline = isoGroup.findOne('.whd-iso-outline');
+
+        if (topFace && geometry.top) {
+            topFace.points(geometry.top);
+        }
+
+        if (leftFace && geometry.left) {
+            leftFace.points(geometry.left);
+        }
+
+        if (rightFace && geometry.right) {
+            rightFace.points(geometry.right);
+        }
+
+        if (outline && geometry.outline) {
+            outline.points(geometry.outline);
+        }
+    }
+
+    function createCottageNode(options) {
+        if (typeof Konva === 'undefined') {
+            return null;
+        }
+
+        const normalized = options || {};
+        const gridSize = normalized.gridSize || 50;
+        const scaleRatio = normalized.scaleRatio && normalized.scaleRatio > 0 ? normalized.scaleRatio : 1;
+        const pixelsPerMeter = gridSize / scaleRatio;
+        const widthMeters = normalized.widthMeters;
+        const depthMeters = normalized.depthMeters;
+        const heightMeters = normalized.heightMeters;
+
+        const widthPx = widthMeters * pixelsPerMeter;
+        const depthPx = depthMeters * pixelsPerMeter;
+        const heightPx = heightMeters * pixelsPerMeter;
+
+        const group = new Konva.Group({
+            x: gridSize * 2,
+            y: gridSize * 2,
+            draggable: true,
+            name: 'cottage whd-draggable'
+        });
+
+        group.setAttr('whdDimensions', {
+            widthMeters: widthMeters,
+            depthMeters: depthMeters,
+            heightMeters: heightMeters
+        });
+
+        group.setAttr('whdPixelSize', {
+            widthPx: widthPx,
+            depthPx: depthPx,
+            heightPx: heightPx
+        });
+
+        const topView = new Konva.Group({ name: 'whd-top-view' });
+        const rect = new Konva.Rect({
+            x: 0,
+            y: 0,
+            width: widthPx,
+            height: depthPx,
+            fill: 'rgba(66, 153, 225, 0.25)',
+            stroke: '#2b6cb0',
+            strokeWidth: 2,
+            name: 'whd-top-rect'
+        });
+
+        topView.add(rect);
+        group.add(topView);
+
+        const isoGroup = new Konva.Group({
+            name: 'whd-iso-view',
+            visible: false
+        });
+
+        const geometry = buildIsometricGeometry(widthPx, depthPx, heightPx);
+
+        isoGroup.add(new Konva.Line({
+            points: geometry.left,
+            closed: true,
+            fill: 'rgba(59, 130, 246, 0.35)',
+            stroke: '#1e3a8a',
+            strokeWidth: 1,
+            name: 'whd-iso-left'
+        }));
+
+        isoGroup.add(new Konva.Line({
+            points: geometry.right,
+            closed: true,
+            fill: 'rgba(37, 99, 235, 0.45)',
+            stroke: '#1e3a8a',
+            strokeWidth: 1,
+            name: 'whd-iso-right'
+        }));
+
+        isoGroup.add(new Konva.Line({
+            points: geometry.top,
+            closed: true,
+            fill: 'rgba(191, 219, 254, 0.55)',
+            stroke: '#1e3a8a',
+            strokeWidth: 1,
+            name: 'whd-iso-top'
+        }));
+
+        isoGroup.add(new Konva.Line({
+            points: geometry.outline,
+            closed: false,
+            stroke: '#1e3a8a',
+            strokeWidth: 1.5,
+            name: 'whd-iso-outline'
+        }));
+
+        group.add(isoGroup);
+
+        return group;
+    }
 
     function buildConfig(config) {
         const normalized = config || {};
@@ -52,33 +308,31 @@
             const raw = templates[index] || {};
             const width = parseFloat(raw.width);
             const depth = parseFloat(raw.depth);
+            const heightValue = parseFloat(raw.height);
 
             if (!width || width <= 0 || !depth || depth <= 0) {
                 continue;
             }
 
-            const pixelsPerMeter = gridSize / (scaleRatio || 1);
-            const widthPx = width * pixelsPerMeter;
-            const depthPx = depth * pixelsPerMeter;
+            const heightMeters = heightValue && heightValue > 0 ? heightValue : 3;
             const replacements = {
                 width: String(parseFloat(width.toFixed(2))),
-                depth: String(parseFloat(depth.toFixed(2)))
+                depth: String(parseFloat(depth.toFixed(2))),
+                height: String(parseFloat(heightMeters.toFixed(2)))
             };
 
             items.push({
                 id: 'cottage-' + index,
                 label: formatTemplate(labelTemplate, replacements),
-                factory: function () {
-                    return new Konva.Rect({
-                        x: gridSize * 2,
-                        y: gridSize * 2,
-                        width: widthPx,
-                        height: depthPx,
-                        fill: 'rgba(66, 153, 225, 0.25)',
-                        stroke: '#2b6cb0',
-                        strokeWidth: 2,
-                        draggable: true,
-                        name: 'cottage'
+                factory: function (options) {
+                    const currentGrid = options && options.gridSize ? options.gridSize : gridSize;
+                    const currentScale = options && options.scaleRatio ? options.scaleRatio : scaleRatio;
+                    return createCottageNode({
+                        gridSize: currentGrid,
+                        scaleRatio: currentScale,
+                        widthMeters: width,
+                        depthMeters: depth,
+                        heightMeters: heightMeters
                     });
                 }
             });
@@ -87,7 +341,7 @@
         return items;
     }
 
-    function drawGrid(layer, width, height, gridSize, scaleRatio) {
+    function drawGrid(layer, width, height, gridSize, scaleRatio, mode) {
         layer.destroyChildren();
 
         const elements = [];
@@ -95,41 +349,81 @@
         const majorColor = '#a0aec0';
         const minorColor = '#e2e8f0';
 
-        for (let i = 0; i <= width / gridSize; i++) {
-            const isMajor = i % majorEvery === 0;
-            elements.push(new Konva.Line({
-                points: [i * gridSize, 0, i * gridSize, height],
-                stroke: isMajor ? majorColor : minorColor,
-                strokeWidth: isMajor ? 1 : 0.5
-            }));
+        if (mode === 'iso') {
+            const tileWidth = gridSize;
+            const tileHeight = gridSize * 0.5;
+            const horizontalCount = Math.ceil(width / tileWidth) + Math.ceil(height / tileHeight);
+            const verticalCount = horizontalCount;
+            const centerX = width / 2;
+            const offsetY = tileHeight * 2;
 
-            if (isMajor && i > 0) {
-                elements.push(new Konva.Text({
-                    x: i * gridSize + 4,
-                    y: 4,
-                    text: (i * scaleRatio).toFixed(2) + ' m',
-                    fontSize: 10,
-                    fill: '#4a5568'
+            for (let i = -horizontalCount; i <= horizontalCount; i++) {
+                const isMajor = i % majorEvery === 0;
+                const start = projectIsometric(i * tileWidth, -verticalCount * tileWidth, 0);
+                const end = projectIsometric(i * tileWidth, verticalCount * tileWidth, 0);
+                elements.push(new Konva.Line({
+                    points: [start.x + centerX, start.y + offsetY, end.x + centerX, end.y + offsetY],
+                    stroke: isMajor ? majorColor : minorColor,
+                    strokeWidth: isMajor ? 1 : 0.5
                 }));
             }
-        }
 
-        for (let j = 0; j <= height / gridSize; j++) {
-            const isMajor = j % majorEvery === 0;
-            elements.push(new Konva.Line({
-                points: [0, j * gridSize, width, j * gridSize],
-                stroke: isMajor ? majorColor : minorColor,
-                strokeWidth: isMajor ? 1 : 0.5
-            }));
-
-            if (isMajor && j > 0) {
-                elements.push(new Konva.Text({
-                    x: 4,
-                    y: j * gridSize + 4,
-                    text: (j * scaleRatio).toFixed(2) + ' m',
-                    fontSize: 10,
-                    fill: '#4a5568'
+            for (let j = -verticalCount; j <= verticalCount; j++) {
+                const isMajor = j % majorEvery === 0;
+                const start = projectIsometric(-horizontalCount * tileWidth, j * tileWidth, 0);
+                const end = projectIsometric(horizontalCount * tileWidth, j * tileWidth, 0);
+                elements.push(new Konva.Line({
+                    points: [start.x + centerX, start.y + offsetY, end.x + centerX, end.y + offsetY],
+                    stroke: isMajor ? majorColor : minorColor,
+                    strokeWidth: isMajor ? 1 : 0.5
                 }));
+            }
+
+            for (let h = 0; h <= Math.ceil(height / tileHeight); h++) {
+                const y = offsetY + h * tileHeight;
+                elements.push(new Konva.Line({
+                    points: [0, y, width, y],
+                    stroke: h % majorEvery === 0 ? majorColor : minorColor,
+                    strokeWidth: h % majorEvery === 0 ? 1 : 0.5
+                }));
+            }
+        } else {
+            for (let i = 0; i <= width / gridSize; i++) {
+                const isMajor = i % majorEvery === 0;
+                elements.push(new Konva.Line({
+                    points: [i * gridSize, 0, i * gridSize, height],
+                    stroke: isMajor ? majorColor : minorColor,
+                    strokeWidth: isMajor ? 1 : 0.5
+                }));
+
+                if (isMajor && i > 0) {
+                    elements.push(new Konva.Text({
+                        x: i * gridSize + 4,
+                        y: 4,
+                        text: (i * scaleRatio).toFixed(2) + ' m',
+                        fontSize: 10,
+                        fill: '#4a5568'
+                    }));
+                }
+            }
+
+            for (let j = 0; j <= height / gridSize; j++) {
+                const isMajor = j % majorEvery === 0;
+                elements.push(new Konva.Line({
+                    points: [0, j * gridSize, width, j * gridSize],
+                    stroke: isMajor ? majorColor : minorColor,
+                    strokeWidth: isMajor ? 1 : 0.5
+                }));
+
+                if (isMajor && j > 0) {
+                    elements.push(new Konva.Text({
+                        x: 4,
+                        y: j * gridSize + 4,
+                        text: (j * scaleRatio).toFixed(2) + ' m',
+                        fontSize: 10,
+                        fill: '#4a5568'
+                    }));
+                }
             }
         }
 
@@ -157,17 +451,30 @@
             return '';
         }
 
-        const box = node.getClientRect({ skipShadow: true, skipStroke: false });
         const gridSize = config.gridSize || 50;
         const scaleRatio = config.scaleRatio || 1;
-        const widthMeters = (box.width / gridSize * scaleRatio).toFixed(2);
-        const heightMeters = (box.height / gridSize * scaleRatio).toFixed(2);
+        const dimensions = node.getAttr('whdDimensions');
+        let widthMeters;
+        let depthMeters;
+        let heightMeters;
+
+        if (dimensions) {
+            widthMeters = dimensions.widthMeters.toFixed(2);
+            depthMeters = dimensions.depthMeters.toFixed(2);
+            heightMeters = dimensions.heightMeters.toFixed(2);
+        } else {
+            const box = node.getClientRect({ skipShadow: true, skipStroke: false });
+            widthMeters = (box.width / gridSize * scaleRatio).toFixed(2);
+            depthMeters = (box.height / gridSize * scaleRatio).toFixed(2);
+            heightMeters = '0.00';
+        }
         const rawName = typeof node.name === 'function' && node.name() ? node.name() : node.className || 'shape';
         const formattedName = rawName.charAt(0).toUpperCase() + rawName.slice(1);
 
         return formatTemplate(config.strings.selectedStatus, {
             name: formattedName,
             width: widthMeters,
+            depth: depthMeters,
             height: heightMeters
         });
     }
@@ -177,9 +484,9 @@
             return;
         }
 
-        const box = node.getClientRect({ skipShadow: true, skipStroke: false });
         const gridSize = config.gridSize || 50;
         const scaleRatio = config.scaleRatio || 1;
+        const box = node.getClientRect({ skipShadow: true, skipStroke: false });
         const widthMeters = (box.width / gridSize * scaleRatio).toFixed(2);
         const textNode = node.findOne('Text');
 
@@ -202,8 +509,10 @@
         const transformerRef = useRef(null);
         const resizeTimerRef = useRef(null);
         const statusRef = useRef('');
+        const viewModeRef = useRef('top');
 
         const [status, setStatus] = useState('');
+        const [viewMode, setViewMode] = useState('top');
 
         const updateStatus = useCallback(function (message) {
             if (statusRef.current === message) {
@@ -265,7 +574,7 @@
                     width: containerWidth || width,
                     height: containerHeight || height
                 });
-                drawGrid(gridLayer, stage.width(), stage.height(), config.gridSize, config.scaleRatio);
+                drawGrid(gridLayer, stage.width(), stage.height(), config.gridSize, config.scaleRatio, viewModeRef.current);
             }
 
             const handleResize = function () {
@@ -282,12 +591,20 @@
                     return;
                 }
 
-                if (!evt.target.draggable()) {
+                let target = evt.target;
+
+                while (target && target !== stage && !target.draggable()) {
+                    target = target.getParent();
+                }
+
+                if (!target || target === stage) {
+                    transformer.nodes([]);
+                    updateStatus('');
                     return;
                 }
 
-                transformer.nodes([evt.target]);
-                updateStatus(getDimensions(evt.target, config));
+                transformer.nodes([target]);
+                updateStatus(getDimensions(target, config));
             };
 
             const handleStageMouseMove = function () {
@@ -297,6 +614,10 @@
                 }
 
                 if (transformer.nodes().length > 0) {
+                    return;
+                }
+
+                if (viewModeRef.current !== 'top') {
                     return;
                 }
 
@@ -346,6 +667,37 @@
             };
         }, [config, updateStatus]);
 
+        useEffect(function () {
+            viewModeRef.current = viewMode;
+
+            if (gridLayerRef.current && stageRef.current) {
+                drawGrid(
+                    gridLayerRef.current,
+                    stageRef.current.width(),
+                    stageRef.current.height(),
+                    config.gridSize,
+                    config.scaleRatio,
+                    viewMode
+                );
+            }
+
+            if (drawingLayerRef.current) {
+                drawingLayerRef.current.getChildren().forEach(function (node) {
+                    applyViewModeToNode(node, viewMode);
+                });
+                drawingLayerRef.current.batchDraw();
+            }
+
+            const transformer = transformerRef.current;
+            if (transformer && transformer.nodes().length > 0) {
+                updateStatus(getDimensions(transformer.nodes()[0], config));
+            } else if (viewMode === 'iso') {
+                updateStatus(config.strings.isoViewStatus);
+            } else {
+                updateStatus(config.strings.ready);
+            }
+        }, [config, updateStatus, viewMode]);
+
         const handleToolClick = useCallback(function (tool) {
             if (!drawingLayerRef.current || !transformerRef.current) {
                 return;
@@ -356,11 +708,38 @@
                 scaleRatio: config.scaleRatio
             });
 
+            if (!node) {
+                return;
+            }
+
+            updateIsometricGeometry(node, config);
+            applyViewModeToNode(node, viewModeRef.current);
+
             node.on('dragmove transform', function () {
                 updateDimensionLabel(node, config);
                 if (transformerRef.current && transformerRef.current.nodes().includes(node)) {
                     updateStatus(getDimensions(node, config));
                 }
+            });
+
+            node.on('transformend', function () {
+                const dims = node.getAttr('whdDimensions');
+                if (!dims) {
+                    return;
+                }
+
+                const scaleX = node.scaleX() || 1;
+                const scaleY = node.scaleY() || 1;
+                const newDimensions = {
+                    widthMeters: parseFloat((dims.widthMeters * scaleX).toFixed(2)),
+                    depthMeters: parseFloat((dims.depthMeters * scaleY).toFixed(2)),
+                    heightMeters: dims.heightMeters
+                };
+
+                node.setAttr('whdDimensions', newDimensions);
+                node.scale({ x: 1, y: 1 });
+                updateIsometricGeometry(node, config);
+                updateStatus(getDimensions(node, config));
             });
 
             if (drawingLayerRef.current) {
@@ -408,7 +787,33 @@
             el(
                 'div',
                 { className: 'whd-header' },
-                el('h1', { className: 'whd-header__title' }, config.strings.appTitle)
+                el('h1', { className: 'whd-header__title' }, config.strings.appTitle),
+                el(
+                    'div',
+                    { className: 'whd-view-toggle', role: 'group', 'aria-label': config.strings.viewToggleLabel },
+                    el(
+                        'button',
+                        {
+                            type: 'button',
+                            className: 'whd-view-toggle__button' + (viewMode === 'top' ? ' whd-view-toggle__button--active' : ''),
+                            onClick: function () {
+                                setViewMode('top');
+                            }
+                        },
+                        config.strings.viewTop
+                    ),
+                    el(
+                        'button',
+                        {
+                            type: 'button',
+                            className: 'whd-view-toggle__button' + (viewMode === 'iso' ? ' whd-view-toggle__button--active' : ''),
+                            onClick: function () {
+                                setViewMode('iso');
+                            }
+                        },
+                        config.strings.viewIso
+                    )
+                )
             ),
             el(
                 'div',

--- a/includes/class-wood-house-designer-settings.php
+++ b/includes/class-wood-house-designer-settings.php
@@ -277,16 +277,22 @@ if ( ! class_exists( 'Wood_House_Designer_Settings' ) ) {
                         continue;
                     }
 
-                    $width = isset( $item['width'] ) ? (float) $item['width'] : 0.0;
-                    $depth = isset( $item['depth'] ) ? (float) $item['depth'] : 0.0;
+                    $width  = isset( $item['width'] ) ? (float) $item['width'] : 0.0;
+                    $depth  = isset( $item['depth'] ) ? (float) $item['depth'] : 0.0;
+                    $height = isset( $item['height'] ) ? (float) $item['height'] : 0.0;
 
                     if ( $width <= 0 || $depth <= 0 ) {
                         continue;
                     }
 
+                    if ( $height <= 0 ) {
+                        $height = 3.0;
+                    }
+
                     $casette[] = array(
-                        'width' => round( $width, 2 ),
-                        'depth' => round( $depth, 2 ),
+                        'width'  => round( $width, 2 ),
+                        'depth'  => round( $depth, 2 ),
+                        'height' => round( $height, 2 ),
                     );
                 }
 
@@ -300,7 +306,7 @@ if ( ! class_exists( 'Wood_House_Designer_Settings' ) ) {
          * Render introduction text for cottages section.
          */
         public function render_casette_section_intro() {
-            echo '<p>' . esc_html__( 'Define the list of cottage footprints available in the designer. Width and depth are expressed in meters.', 'wood-house-designer' ) . '</p>';
+            echo '<p>' . esc_html__( 'Define the list of cottage volumes available in the designer. Width, depth, and height are expressed in meters.', 'wood-house-designer' ) . '</p>';
         }
 
         /**
@@ -317,8 +323,9 @@ if ( ! class_exists( 'Wood_House_Designer_Settings' ) ) {
                         <p class="whd-casette-empty"><?php esc_html_e( 'No cottages configured yet.', 'wood-house-designer' ); ?></p>
                     <?php else : ?>
                         <?php foreach ( $casette as $index => $item ) :
-                            $width = isset( $item['width'] ) ? $item['width'] : '';
-                            $depth = isset( $item['depth'] ) ? $item['depth'] : '';
+                            $width  = isset( $item['width'] ) ? $item['width'] : '';
+                            $depth  = isset( $item['depth'] ) ? $item['depth'] : '';
+                            $height = isset( $item['height'] ) ? $item['height'] : '3';
                             ?>
                             <div class="whd-casetta-row" data-index="<?php echo esc_attr( $index ); ?>">
                                 <div class="whd-casetta-field">
@@ -331,6 +338,12 @@ if ( ! class_exists( 'Wood_House_Designer_Settings' ) ) {
                                     <label>
                                         <?php esc_html_e( 'Depth (m)', 'wood-house-designer' ); ?>
                                         <input type="number" min="0" step="0.01" name="<?php echo esc_attr( $field_name . '[' . $index . '][depth]' ); ?>" value="<?php echo esc_attr( $depth ); ?>" />
+                                    </label>
+                                </div>
+                                <div class="whd-casetta-field">
+                                    <label>
+                                        <?php esc_html_e( 'Height (m)', 'wood-house-designer' ); ?>
+                                        <input type="number" min="0" step="0.01" name="<?php echo esc_attr( $field_name . '[' . $index . '][height]' ); ?>" value="<?php echo esc_attr( $height ); ?>" />
                                     </label>
                                 </div>
                                 <button type="button" class="button whd-remove-casetta"><?php esc_html_e( 'Remove', 'wood-house-designer' ); ?></button>
@@ -352,6 +365,12 @@ if ( ! class_exists( 'Wood_House_Designer_Settings' ) ) {
                         <label>
                             <?php esc_html_e( 'Depth (m)', 'wood-house-designer' ); ?>
                             <input type="number" min="0" step="0.01" name="<?php echo esc_attr( $field_name ); ?>[{{index}}][depth]" value="" />
+                        </label>
+                    </div>
+                    <div class="whd-casetta-field">
+                        <label>
+                            <?php esc_html_e( 'Height (m)', 'wood-house-designer' ); ?>
+                            <input type="number" min="0" step="0.01" name="<?php echo esc_attr( $field_name ); ?>[{{index}}][height]" value="3" />
                         </label>
                     </div>
                     <button type="button" class="button whd-remove-casetta"><?php esc_html_e( 'Remove', 'wood-house-designer' ); ?></button>

--- a/includes/class-wood-house-designer.php
+++ b/includes/class-wood-house-designer.php
@@ -131,11 +131,15 @@ if ( ! class_exists( 'Wood_House_Designer' ) ) {
                         'exportUnavailable'=> esc_html__( 'Unable to export the project right now.', 'wood-house-designer' ),
                         'errorKonva'       => esc_html__( 'The drawing library is not available. Please refresh the page.', 'wood-house-designer' ),
                         'cursorStatus'     => esc_html__( 'Cursor: %x% × %y% m', 'wood-house-designer' ),
-                        'selectedStatus'   => esc_html__( 'Selected %name% - %width%m × %height%m', 'wood-house-designer' ),
-                        'cottageLabel'     => esc_html__( 'Cottage %width%m × %depth%m', 'wood-house-designer' ),
+                        'selectedStatus'   => esc_html__( 'Selected %name% - %width%m × %depth%m × %height%m', 'wood-house-designer' ),
+                        'cottageLabel'     => esc_html__( 'Cottage %width%m × %depth%m × %height%m', 'wood-house-designer' ),
                         'noCottages'       => esc_html__( 'No cottages configured yet.', 'wood-house-designer' ),
                         'designCanvas'     => esc_html__( 'Design Canvas', 'wood-house-designer' ),
                         'toolbox'          => esc_html__( 'Toolbox', 'wood-house-designer' ),
+                        'viewTop'          => esc_html__( 'Top View', 'wood-house-designer' ),
+                        'viewIso'          => esc_html__( 'Isometric View', 'wood-house-designer' ),
+                        'viewToggleLabel'  => esc_html__( 'View mode', 'wood-house-designer' ),
+                        'isoViewStatus'    => esc_html__( 'Isometric view active.', 'wood-house-designer' ),
                     ),
                 )
             );


### PR DESCRIPTION
## Summary
- add a header view toggle to switch between top-down and isometric grids
- render cottages as draggable 3D prisms with height-aware status messaging
- capture cottage height in the admin settings UI and adjust styles for the additional field

## Testing
- php -l includes/class-wood-house-designer.php
- php -l includes/class-wood-house-designer-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cbeb6227148332b6a17732a67163bd