### PR TITLE
Add custom polygon cottages creation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -92,6 +92,14 @@
     letter-spacing: 0.04em;
 }
 
+.whd-tools__subtitle {
+    font-size: 0.9rem;
+    margin: 0 0 0.5rem;
+    text-transform: uppercase;
+    color: var(--whd-primary);
+    letter-spacing: 0.04em;
+}
+
 .whd-tools__list {
     list-style: none;
     padding: 0;
@@ -121,6 +129,46 @@
     background: #edf2f7;
     box-shadow: 0 0 0 3px rgba(47, 133, 90, 0.25);
     outline: none;
+}
+
+.whd-custom-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.whd-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+}
+
+.whd-field__label {
+    font-weight: 600;
+    color: var(--whd-text);
+}
+
+.whd-field__input {
+    border: 1px solid var(--whd-border);
+    border-radius: 4px;
+    padding: 0.45rem 0.5rem;
+    font-size: 0.9rem;
+}
+
+.whd-field__input:focus {
+    border-color: var(--whd-primary);
+    box-shadow: 0 0 0 2px rgba(47, 133, 90, 0.25);
+    outline: none;
+}
+
+.whd-field__error {
+    color: #c53030;
+    font-size: 0.8rem;
+}
+
+.whd-custom-form__button {
+    align-self: flex-start;
 }
 
 .whd-canvas {

--- a/includes/class-wood-house-designer.php
+++ b/includes/class-wood-house-designer.php
@@ -140,6 +140,14 @@ if ( ! class_exists( 'Wood_House_Designer' ) ) {
                         'viewIso'          => esc_html__( 'Isometric View', 'wood-house-designer' ),
                         'viewToggleLabel'  => esc_html__( 'View mode', 'wood-house-designer' ),
                         'isoViewStatus'    => esc_html__( 'Isometric view active.', 'wood-house-designer' ),
+                        'customHeading'    => esc_html__( 'Create custom cottage', 'wood-house-designer' ),
+                        'sidesLabel'       => esc_html__( 'Number of sides', 'wood-house-designer' ),
+                        'widthLabel'       => esc_html__( 'Width / bounding width (m)', 'wood-house-designer' ),
+                        'depthLabel'       => esc_html__( 'Depth / bounding depth (m)', 'wood-house-designer' ),
+                        'heightLabel'      => esc_html__( 'Height (m)', 'wood-house-designer' ),
+                        'addPolygonButton' => esc_html__( 'Add polygon', 'wood-house-designer' ),
+                        'invalidPolygon'   => esc_html__( 'Please provide valid values for sides and dimensions.', 'wood-house-designer' ),
+                        'customAdded'      => esc_html__( 'Custom cottage added to toolbox.', 'wood-house-designer' ),
                     ),
                 )
             );


### PR DESCRIPTION
## Summary
- enable adding custom cottages directly from the template toolbox through a new form with validation
- extend the drawing engine to support regular polygon prisms, including updated isometric rendering and metadata handling
- add supporting strings and styles for the custom polygon workflow

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc056eee208332becef88874f318db