### PR TITLE
Ensure isometric polygons align with orthogonal view and update cottage list UI

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -174,22 +174,12 @@
     line-height: 1;
 }
 
-.whd-tool-button__label {
-    font-weight: 600;
-    font-size: 0.95rem;
-    color: var(--whd-text);
-}
-
 .whd-tool-button__dims {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.35rem;
-    font-size: 0.8rem;
-    background: rgba(255, 255, 255, 0.7);
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 0.75rem;
     color: #1a202c;
-    padding: 0.35rem 0.5rem;
-    border-radius: 999px;
+    opacity: 0.85;
 }
 
 .whd-tool-button__dims-item {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -305,6 +305,20 @@
             };
         });
 
+        const baseOffsetY = adjustedBottom.reduce(function (min, point) {
+            return Math.min(min, point.y);
+        }, Infinity);
+
+        if (baseOffsetY !== Infinity && baseOffsetY !== 0) {
+            for (let index = 0; index < adjustedTop.length; index++) {
+                adjustedTop[index].y -= baseOffsetY;
+            }
+
+            for (let index = 0; index < adjustedBottom.length; index++) {
+                adjustedBottom[index].y -= baseOffsetY;
+            }
+        }
+
         const top = [];
         adjustedTop.forEach(function (point) {
             top.push(point.x, point.y);
@@ -1293,6 +1307,14 @@
 
                 const className = 'whd-tool-button whd-tool-button--' + variant;
 
+                const dimsText =
+                    widthValue.toFixed(2) +
+                    ' m × ' +
+                    depthValue.toFixed(2) +
+                    ' m × ' +
+                    heightValue.toFixed(2) +
+                    ' m';
+
                 return el(
                     'li',
                     { key: tool.id },
@@ -1307,16 +1329,7 @@
                             'aria-label': tool.label
                         },
                         el('span', { className: 'whd-tool-button__icon', 'aria-hidden': 'true' }, '🏠'),
-                        el('span', { className: 'whd-tool-button__label' }, tool.label),
-                        el(
-                            'span',
-                            { className: 'whd-tool-button__dims' },
-                            el('span', { className: 'whd-tool-button__dims-item' }, widthValue.toFixed(2) + ' m'),
-                            el('span', { className: 'whd-tool-button__dims-separator', 'aria-hidden': 'true' }, '×'),
-                            el('span', { className: 'whd-tool-button__dims-item' }, depthValue.toFixed(2) + ' m'),
-                            el('span', { className: 'whd-tool-button__dims-separator', 'aria-hidden': 'true' }, '×'),
-                            el('span', { className: 'whd-tool-button__dims-item' }, heightValue.toFixed(2) + ' m')
-                        )
+                        el('span', { className: 'whd-tool-button__dims' }, dimsText)
                     )
                 );
             });


### PR DESCRIPTION
## Summary
- anchor custom polygon solids to the horizontal plane so isometric shapes reflect orthogonal positioning
- streamline cottage toolbox buttons to show only the icon with compact dimension text beneath

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc13fcfbf08332b96a6c7546566fc1