### PR TITLE
Center isometric view and add zoom controls

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -247,6 +247,49 @@
     overflow: hidden;
 }
 
+.whd-canvas__stage-wrapper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.whd-zoom-controls {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 5;
+}
+
+.whd-zoom-controls__button {
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    border: 1px solid var(--whd-border);
+    background-color: rgba(255, 255, 255, 0.9);
+    color: var(--whd-text);
+    font-size: 1.25rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.whd-zoom-controls__button:hover:not(:disabled) {
+    background-color: #edf2f7;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.15);
+}
+
+.whd-zoom-controls__button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+}
+
 .whd-status {
     min-height: 38px;
     display: flex;


### PR DESCRIPTION
## Summary
- recenter the isometric view by computing content bounds and refreshing grid placement when switching modes
- introduce zoom state, scaling helpers, and UI buttons to let users zoom in/out of the canvas
- style the new zoom controls and provide localized labels for accessibility

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd14b9f2e0833293e31c8813902640